### PR TITLE
feat(unbaptised publisher): add an event for new ubaptised publisher

### DIFF
--- a/src/localization/locales/sv/translation.json
+++ b/src/localization/locales/sv/translation.json
@@ -475,5 +475,6 @@
   "Växla &Utvecklarverktyg": "Växla &Utvecklarverktyg",
   "Växla utvecklarverktyg": "Växla Utvecklarverktyg",
   "Ångra": "Ångra",
-  "updates.newVersion": "Det finns en ny version, {{tag}}!"
+  "updates.newVersion": "Det finns en ny version, {{tag}}!",
+  "event.publisher": "Blivit odöpt förkunnare"
 }

--- a/src/main/functions/storeEvent.ts
+++ b/src/main/functions/storeEvent.ts
@@ -23,6 +23,9 @@ async function storeEvent(event: EventProps): Promise<void> {
   let removeFromActiveReports = false
 
   switch (event.command) {
+    case 'PUBLISHER':
+      information = `${publisher?.firstname} ${publisher?.lastname}`
+      break
     case 'AUXILIARY_START':
       if (!publisher.appointments.find(appointment => appointment.type === 'PIONEER' || appointment.type === 'AUXILIARY')) {
         information = `${publisher?.firstname} ${publisher?.lastname}`

--- a/src/renderer/src/pages/publishers/components/eventModal.tsx
+++ b/src/renderer/src/pages/publishers/components/eventModal.tsx
@@ -37,6 +37,7 @@ export default function EventModal(props: EventModalProps): JSX.Element {
   const events: Event[] = [
     { name: t('event.movedIn'), command: 'MOVED_IN' },
     { name: t('event.movedOut'), command: 'MOVED_OUT' },
+    { name: t('event.publisher'), command: 'PUBLISHER' },
     { name: t('event.auxiliaryStart'), command: 'AUXILIARY_START' },
     { name: t('event.pioneerStart'), command: 'PIONEER_START' },
     { name: t('event.auxiliaryStop'), command: 'AUXILIARY_STOP' },


### PR DESCRIPTION
The event will be stored in the publishers personal history and in the current service year

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Under Lägg till händelse på en förkunnare dyker det upp ett nytt alternativ "Blivit odöpt förkunnare".
Informationen sparas i förkunnarens historik och på församlingens aktuella tjänsteår

### Linked Issues

#407

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
